### PR TITLE
Crazy Amigos paragraph aligned for xs device view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -217,7 +217,7 @@ nav a#pull {
 	font-size: 2.6em;
 	font-weight: 600;
 	color: #888888;
-	margin-top: -175px;
+	margin-top: -115px;
 	
 }
 .ca-content p{


### PR DESCRIPTION
In larger device, Crazy Amigos image below paragraph is perfect.
but in small device this paragraph moving to top of image.
Here i Fixed this problem.